### PR TITLE
Feature/hide muted channels

### DIFF
--- a/src/store/data/actions/createCommunity.ts
+++ b/src/store/data/actions/createCommunity.ts
@@ -203,9 +203,10 @@ export default async ({
         },
         useLocalTheme: false,
         currentChannelId: null,
+        hideMutedChannels: false,
         notifications: {
-          mute: false
-        }
+          mute: false,
+        },
       },
     } as CommunityState;
 

--- a/src/store/data/actions/joinCommunity.ts
+++ b/src/store/data/actions/joinCommunity.ts
@@ -100,9 +100,10 @@ export default async ({ joiningLink }: Payload): Promise<void> => {
             saturation: 60,
           },
           currentChannelId: null,
+          hideMutedChannels: false,
           notifications: {
-            mute: false
-          }
+            mute: false,
+          },
         },
       } as CommunityState;
 

--- a/src/store/data/mutations/index.ts
+++ b/src/store/data/mutations/index.ts
@@ -138,7 +138,7 @@ export default {
     if (community.notifications) {
       community.notifications.mute = !community.notifications.mute;
     } else {
-      community.notifications = { mute: true }
+      community.notifications = { mute: true };
     }
   },
 
@@ -236,17 +236,10 @@ export default {
     state.channels[payload.perspectiveUuid] = payload.channel;
   },
 
-  toggleHideMutedChannels(payload: {
-    communityId: string;
-  }): void {
+  toggleHideMutedChannels(payload: { communityId: string }): void {
     const state = useDataStore();
     const community = state.communities[payload.communityId];
-    
-    if (community.collapseChannelList !== undefined) {
-      community.collapseChannelList = !community.collapseChannelList;
-    } else {
-      community.collapseChannelList = false;
-    }
+    community.hideMutedChannels = !community.hideMutedChannels;
   },
 
   createChannelMutation(payload: ChannelState): void {
@@ -265,16 +258,19 @@ export default {
   setHasNewMessages(payload: { channelId: string; value: boolean }): void {
     const state = useDataStore();
     const tempChannel = state.getChannel(payload.channelId);
-    const tempCommunity = state.getCommunity(tempChannel.neighbourhood.membraneRoot);
+    const tempCommunity = state.getCommunity(
+      tempChannel.neighbourhood.membraneRoot
+    );
     const channel = state.channels[payload.channelId];
     const community = state.communities[tempCommunity.state.perspectiveUuid];
     channel.hasNewMessages = payload.value;
-    community.hasNewMessages = state.getChannelNeighbourhoods(tempCommunity.state.perspectiveUuid).reduce((acc: boolean, curr) => {
-      const channel = state.channels[curr.perspective.uuid];
-      if (!acc) 
-        return channel.hasNewMessages
-      return true;
-    }, false);
+    community.hasNewMessages = state
+      .getChannelNeighbourhoods(tempCommunity.state.perspectiveUuid)
+      .reduce((acc: boolean, curr) => {
+        const channel = state.channels[curr.perspective.uuid];
+        if (!acc) return channel.hasNewMessages;
+        return true;
+      }, false);
   },
 
   addExpressionAndLink: (payload: {

--- a/src/store/types/community.ts
+++ b/src/store/types/community.ts
@@ -12,7 +12,8 @@ export interface LocalCommunityState {
   useLocalTheme: boolean;
   currentChannelId: string | undefined | null;
   hasNewMessages: boolean;
-  collapseChannelList: boolean,
+  collapseChannelList: boolean;
+  hideMutedChannels: boolean;
   notifications: {
     mute: boolean;
   };

--- a/src/views/main-view/main-sidebar/CommunitiesList.vue
+++ b/src/views/main-view/main-sidebar/CommunitiesList.vue
@@ -17,26 +17,45 @@
           :initials="community.name.charAt(0).toUpperCase()"
           @click="() => handleCommunityClick(community.perspective.uuid)"
         ></j-avatar>
-        <j-menu
-          slot="content"
-        >
-          <j-menu-item 
+        <j-menu slot="content">
+          <j-menu-item
             @click="() => removeCommunity(community.perspective.uuid)"
-          >Remove community</j-menu-item>
-          <j-menu-item 
-            @click="() => muteCommunity(community.perspective.uuid)"
-          ><j-icon
+            >Remove community</j-menu-item
+          >
+
+          <j-menu-item @click="() => muteCommunity(community.perspective.uuid)"
+            ><j-icon
               size="xs"
               slot="start"
               :name="
-                getCommunityState(community.perspective.uuid).notifications?.mute ? 'bell-slash' : 'bell'
+                getCommunityState(community.perspective.uuid).notifications
+                  ?.mute
+                  ? 'bell-slash'
+                  : 'bell'
               "
             />
             {{
               `${
-                  getCommunityState(community.perspective.uuid).notifications?.mute ? "Unmute" : "Mute"
+                getCommunityState(community.perspective.uuid).notifications
+                  ?.mute
+                  ? "Unmute"
+                  : "Mute"
               } Community`
             }}
+          </j-menu-item>
+          <j-menu-item
+            @click="() => toggleHideMutedChannels(community.perspective.uuid)"
+          >
+            <j-icon
+              size="xs"
+              slot="start"
+              :name="
+                getCommunityState(community.perspective.uuid).hideMutedChannels
+                  ? 'toggle-on'
+                  : 'toggle-off'
+              "
+            />
+            Hide muted channels
           </j-menu-item>
         </j-menu>
       </j-popover>
@@ -72,9 +91,12 @@ export default defineComponent({
     };
   },
   methods: {
+    toggleHideMutedChannels(id: string) {
+      this.dataStore.toggleHideMutedChannels({ communityId: id });
+    },
     muteCommunity(id: string) {
-      this.dataStore.toggleCommunityMute({communityId: id})
-    },  
+      this.dataStore.toggleCommunityMute({ communityId: id });
+    },
     removeCommunity(id: string) {
       this.$router.push({ name: "home" }).then(() => {
         this.dataStore.removeCommunity(id);
@@ -102,8 +124,8 @@ export default defineComponent({
       };
     },
     getCommunityState() {
-      return (id: string) => this.dataStore.getCommunityState(id)
-    }
+      return (id: string) => this.dataStore.getCommunityState(id);
+    },
   },
 });
 </script>


### PR DESCRIPTION
Fix some UX issues with the current implementation of hide muted channels. Behaviour should be that all muted channels are hidden from view. 